### PR TITLE
Added automated script for env configuration, modified install script to support installing amiga-cc in directories other than $HOME

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,15 +26,11 @@ Type y or n [y]:
 
 Just press enter each time, and the installation will go on.
 
-When finished, copy-paste env.txt contents to your shell to set environment variables (or edit yourself the .profile, .bashrc or whatever config file), for instance bash users can do this way:
-
-```
-cat env.txt >> ~/.bashrc
-```
+When finished, run env.sh file to add entry to your zshrc or bashrc file. 
 
 Nearly the same thing for zsh:
 ```
-cat env.txt >> ~/.zshenv
+./env.sh
 ```
 
 then close and reopen your session.

--- a/env.sh
+++ b/env.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+# Set path to the current working directory
+PROJECT_PATH="$PWD"
+
+# Check if the shell is bash or zsh
+if [ -n "$BASH_VERSION" ]; then
+  SHELL_RC="$HOME/.bashrc"
+elif [ -n "$ZSH_VERSION" ]; then
+  SHELL_RC="$HOME/.zshrc"
+else
+  echo "Unsupported shell. Please use bash or zsh."
+  exit 1
+fi
+
+# Check if entry exist and add it
+if ! grep -q "export VBCC=\"$PROJECT_PATH/vbcc\"" "$SHELL_RC"; then
+  echo "export VBCC=\"$PROJECT_PATH/vbcc\"" >> "$SHELL_RC"
+  echo "Added VBCC environment variable to $SHELL_RC"
+fi
+
+if ! grep -q "export PATH=\"\$VBCC/bin:\$PATH\"" "$SHELL_RC"; then
+  echo "export PATH=\"\$VBCC/bin:\$PATH\"" >> "$SHELL_RC"
+  echo "Added VBCC/bin to PATH in $SHELL_RC"
+fi
+
+echo "Environment configuration completed."

--- a/env.txt
+++ b/env.txt
@@ -1,2 +1,0 @@
-export VBCC=~/amiga-cc/vbcc/
-export PATH=$VBCC/bin:$PATH

--- a/install_amiga_toolchain.sh
+++ b/install_amiga_toolchain.sh
@@ -1,65 +1,102 @@
 #!/bin/sh
 
+# Set the project path to the current working directory
+PROJECT_PATH="$PWD"
+
 if ! command -v wget &> /dev/null
 then
-    echo "Please install wget !"
-    exit
+  echo "Please install wget !"
+  exit
 fi
 
 if ! command -v lha &> /dev/null
 then
-    echo "Please install an lha decompressor !"
-    exit
+  echo "Please install an lha decompressor !"
+  exit
 fi
 
-mkdir vbcc_tools
-mkdir vbcc
-cd vbcc_tools
+mkdir -p "$PROJECT_PATH/vbcc_tools"
+mkdir -p "$PROJECT_PATH/vbcc"
 
-wget http://sun.hasenbraten.de/vasm/release/vasm.tar.gz
-wget http://sun.hasenbraten.de/vlink/release/vlink.tar.gz
-wget http://www.ibaug.de/vbcc/vbcc.tar.gz
-wget http://phoenix.owl.de/vbcc/current/vbcc_target_m68k-amigaos.lha
-wget http://phoenix.owl.de/vbcc/current/vbcc_unix_config.tar.gz
+cd "$PROJECT_PATH/vbcc_tools"
+
+if ! wget -c http://sun.hasenbraten.de/vasm/release/vasm.tar.gz; then
+  echo "Failed to download vasm.tar.gz"
+  exit 1
+fi
+
+if ! wget -c http://sun.hasenbraten.de/vlink/release/vlink.tar.gz; then
+  echo "Failed to download vlink.tar.gz"
+  exit 1
+fi
+
+if ! wget -c http://www.ibaug.de/vbcc/vbcc.tar.gz; then
+  echo "Failed to download vbcc.tar.gz"
+  exit 1
+fi
+
+if ! wget -c http://phoenix.owl.de/vbcc/current/vbcc_target_m68k-amigaos.lha; then
+  echo "Failed to download vbcc_target_m68k-amigaos.lha"
+  exit 1
+fi
+
+if ! wget -c http://phoenix.owl.de/vbcc/current/vbcc_unix_config.tar.gz; then
+  echo "Failed to download vbcc_unix_config.tar.gz"
+  exit 1
+fi
 
 tar zxvf vbcc.tar.gz
 cd vbcc
+
 if [ ! -d bin ]; then
-    mkdir bin
+  mkdir bin
 fi
+
 make TARGET=m68k
-cp -r bin ../../vbcc/
+cp -r bin "$PROJECT_PATH/vbcc/"
 
 cd ..
+
 lha x vbcc_target_m68k-amigaos.lha
-cp -r vbcc_target_m68k-amigaos/* ../vbcc/
+cp -r vbcc_target_m68k-amigaos/* "$PROJECT_PATH/vbcc/"
 
-cd ../vbcc
-tar zxvf ../vbcc_tools/vbcc_unix_config.tar.gz
+cd "$PROJECT_PATH/vbcc"
+tar zxvf "$PROJECT_PATH/vbcc_tools/vbcc_unix_config.tar.gz"
 
-export VBCC=~/amiga-cc/vbcc/
-export PATH=$VBCC/bin:$PATH
+export VBCC="$PROJECT_PATH/vbcc"
+export PATH="$VBCC/bin:$PATH"
 
-cd ../vbcc_tools
+cd "$PROJECT_PATH/vbcc_tools"
+
 tar zxvf vasm.tar.gz
 cd vasm
 make CPU=m68k SYNTAX=mot
-cp vasmm68k_mot vobjdump $VBCC/bin
+cp vasmm68k_mot vobjdump "$VBCC/bin"
 
 cd ..
+
 tar zxvf vlink.tar.gz
 cd vlink
 make
-cp vlink $VBCC/bin
+cp vlink "$VBCC/bin"
 
-cd $VBCC
+cd "$VBCC"
+
 if [ ! -d NDK_3.2 ]; then
-    mkdir NDK_3.2
+  mkdir NDK_3.2
 fi
+
 cd NDK_3.2
-wget http://aminet.net/dev/misc/NDK3.2.lha
+
+if ! wget -c http://aminet.net/dev/misc/NDK3.2.lha; then
+  echo "Failed to download NDK3.2.lha"
+  exit 1
+fi
+
 lha x NDK3.2.lha
+
 cd ..
-cp -r $VBCC/NDK_3.2/Include_h/* $VBCC/targets/m68k-amigaos/include
-rm -rf $VBCC/NDK_3.2/
-rm -rf ~/amiga-cc/vbcc_tools/
+cp -r "$VBCC/NDK_3.2/Include_h/"* "$VBCC/targets/m68k-amigaos/include"
+
+rm -rf "$VBCC/NDK_3.2/"
+rm -rf "$PROJECT_PATH/vbcc_tools/"


### PR DESCRIPTION
Enhance script to enable environment configuration

- Modify the script to use the current working directory ($PWD) as the project path instead of relying on a hardcoded path or the home directory. This allows the script to be executed from any directory, and the project will be set up in that directory.

- Add checks around the wget commands to ensure that the required files are downloaded successfully. 

- Create a separate script (env.sh) to configure the environment permanently by adding the necessary export commands to the .bashrc or .zshrc file based on the current working directory. The script checks the user's shell (bash or zsh) and appends the export commands to the corresponding shell configuration file if they don't already exist.  